### PR TITLE
Packagizing this repo.  Sick of private git urls in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
     "author": "Mark Engel <mark.c.engel@gmail.com> https://github.com/mren",
-    "name": "public-suffix",
+    "name": "@250ok/public-suffix",
     "version": "1.0.0",
     "main": "lib/publicsuffix",
+    "scripts":{
+        "test": "node tests/test-publicsuffix.js"
+    },
     "dependencies": {
         "underscore": "1.3.3"
     }


### PR DESCRIPTION
Making this a private npm package.  Sick of fighting git ssh when building in different envionrments.  Once this is fixed and mod-utils is changed to use it that should get rid of all ssh git packages in package jsons.